### PR TITLE
Replace id="location-titles" with actual locations

### DIFF
--- a/locations.html
+++ b/locations.html
@@ -520,7 +520,7 @@
 <!-- start Warwick -->
 <div id="Warwick" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Warwick, UK</h2>  
+        <h2 class="text-center wowload fadeInDown" id="warwick">Warwick, UK</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>

--- a/locations.html
+++ b/locations.html
@@ -82,7 +82,7 @@
 <!-- start Beijing -->
 <div id="Beijing" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Beijing, China</h2>  
+        <h2 class="text-center wowload fadeInDown" id="beijing">Beijing, China</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -118,7 +118,7 @@
 <!-- start Hangzhuo -->
 <div id="Hangzhuo" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Hangzhuo, China</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Hangzhuo">Hangzhuo, China</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -155,7 +155,7 @@
 <!-- start Singapore -->
 <div id="Singapore" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">TBD, Singapore</h2>  
+        <h2 class="text-center wowload fadeInDown" id="singapore">TBD, Singapore</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -194,7 +194,7 @@
 <!-- start Wako -->
 <div id="Wako" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Wako, Japan</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Wako">Wako, Japan</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-4</p>
@@ -235,7 +235,7 @@
 <div id="Bilbao" class="container">
 >>>>>>> origin/gh-pages
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Bilbao, Spain</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Bilbao">Bilbao, Spain</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -267,7 +267,7 @@
 <!-- start Cambridge -->
 <div id="Cambridge" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Cambridge, UK</h2>  
+        <h2 class="text-center wowload fadeInDown" id="cambridge">Cambridge, UK</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -303,7 +303,7 @@
 <!-- start Leipzig -->
 <div id="Leipzig" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Leipzig, Germany</h2>  
+        <h2 class="text-center wowload fadeInDown" id="leipzig">Leipzig, Germany</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -339,7 +339,7 @@
 <!-- start Linkoping -->
 <div id="Linkoping" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Linkoping, Sweden</h2>  
+        <h2 class="text-center wowload fadeInDown" id="linkoping">Linkoping, Sweden</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -375,7 +375,7 @@
 <!-- start Finland -->
 <div id="Finland" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Oulu, Finland</h2>  
+        <h2 class="text-center wowload fadeInDown" id="finland">Oulu, Finland</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -411,7 +411,7 @@
 <!-- start Paris -->
 <div id="Paris" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Paris, France</h2>  
+        <h2 class="text-center wowload fadeInDown" id="paris">Paris, France</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -448,7 +448,7 @@
 <!-- start Rotterdam -->
 <div id="Rotterdam" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Rotterdam, Netherlands</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Rotterdam">Rotterdam, Netherlands</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -484,7 +484,7 @@
 <!-- start Stockholm -->
 <div id="Stockholm" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Stockholm, Sweden</h2>  
+        <h2 class="text-center wowload fadeInDown" id="stockholm">Stockholm, Sweden</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -551,7 +551,7 @@
 <!-- start York -->
 <div id="York" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">York, Netherlands</h2>  
+        <h2 class="text-center wowload fadeInDown" id="york">York, Netherlands</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -587,7 +587,7 @@
 <!-- start Zurich -->
 <div id="Zurich" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Zurich, Switzerland</h2>  
+        <h2 class="text-center wowload fadeInDown" id="zurich">Zurich, Switzerland</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -622,7 +622,7 @@
 <!-- start Montreal -->
 <div id="Montreal" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Montreal, Canada</h2>  
+        <h2 class="text-center wowload fadeInDown" id="montreal">Montreal, Canada</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -658,7 +658,7 @@
 <!-- start Toronto -->
 <div id="Toronto" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Toronto, Canada</h2>  
+        <h2 class="text-center wowload fadeInDown" id="toronto">Toronto, Canada</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -694,7 +694,7 @@
 <!-- start New Mexico -->
 <div id="New Mexico" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Albequerque, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="albuquerque">Albequerque, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -730,7 +730,7 @@
 <!-- start annarbor -->
 <div id="annarbor" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Ann Arbor, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="annarbor">Ann Arbor, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -760,7 +760,7 @@
 <!-- start Austin -->
 <div id="Austin" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Austin, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Austin">Austin, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -790,7 +790,7 @@
 <!-- start Birmingham -->
 <div id="Birmingham" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Birmingham, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="birmingham">Birmingham, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -826,7 +826,7 @@
 <!-- start bloomington -->
 <div id="Bloomington" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Bloomington, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="bloomington">Bloomington, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -863,7 +863,7 @@
 <!-- start Boston -->
 <div id="Boston" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Boston, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="boston">Boston, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -902,7 +902,7 @@
 <!-- start Boulder -->
 <div id="Boulder" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Boulder, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="boulder">Boulder, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -938,7 +938,7 @@
 <!-- start Charlottesville -->
 <div id="Charlottesville" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Charlottesville, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="charlottesville">Charlottesville, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -975,7 +975,7 @@
 <!-- start DC -->
 <div id="DC" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Washington DC, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="dc">Washington DC, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1011,7 +1011,7 @@
 <!-- start Durham -->
 <div id="Durham" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Durham, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Durham">Durham, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1047,7 +1047,7 @@
 <!-- start Eugene -->
 <div id="Eugene" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Eugene, Oregon</h2>  
+        <h2 class="text-center wowload fadeInDown" id="eugene">Eugene, Oregon</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1079,7 +1079,7 @@
 <!-- start Hanover -->
 <div id="Hanover" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Hanover, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="hanover">Hanover, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1116,7 +1116,7 @@
 <!-- start Iowa City -->
 <div id="Iowa City" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Iowa City, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="iowacity">Iowa City, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1150,7 +1150,7 @@
 <!-- start Madison -->
 <div id="Madison" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Madison, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="madison">Madison, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1186,7 +1186,7 @@
 <!-- start Miami -->
 <div id="Miami" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Miami, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="miami">Miami, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1217,7 +1217,7 @@
 <!-- start NYC -->
 <div id="NYC" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">New York City, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="NYC">New York City, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1247,7 +1247,7 @@
 <!-- start Utah -->
 <div id="Utah" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Salt Lake City, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="saltlakecity">Salt Lake City, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1283,7 +1283,7 @@
 <!-- start San Francisco -->
 <div id="San Francisco" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">San Francisco, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="sanfrancisco">San Francisco, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1324,7 +1324,7 @@
 <!-- start Seattle -->
 <div id="Seattle" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Seattle, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="seattle">Seattle, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1360,7 +1360,7 @@
 <!-- start St. Louis -->
 <div id="St. Louis" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">St. Louis, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="stlouis">St. Louis, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1396,7 +1396,7 @@
 <!-- start Urbana -->
 <div id="Urbana" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Urbana, USA</h2>  
+        <h2 class="text-center wowload fadeInDown" id="urbana">Urbana, USA</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1427,7 +1427,7 @@
 <!-- star mexico -->
 <div id="mx" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Querétaro, Mexico</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Queretaro">Querétaro, Mexico</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1463,7 +1463,7 @@
 <!-- start brasil -->
 <div id="Brasil" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Porto Alegre, Brasil</h2>  
+        <h2 class="text-center wowload fadeInDown" id="porto-alegre">Porto Alegre, Brasil</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>
@@ -1498,7 +1498,7 @@
 <!-- start Melbourne -->
 <div id="Melbourne" class="container">
 <div class="row">
-        <h2 class="text-center wowload fadeInDown" id="locations-title">Melborne, Australia</h2>  
+        <h2 class="text-center wowload fadeInDown" id="Melbourne">Melborne, Australia</h2>  
 
     <div class="col-md-8 col-md-offset-2">
         <p><i class="fa fa-calendar"></i> March 2-5</p>


### PR DESCRIPTION
This PR replaces the `location-titles` placeholders by actual location names so that the link on the index page redirects to the appropriate location. 

E.g. currently http://events.brainhack.org/global2017/locations.html#warwick links to to the top of the locations page because the "warwick" id is not defined.