### PR TITLE
City name for University of Warwick is Coventry

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
       </div>
       <div class="col-sm-4 wowload fadeInRight">
           <img src="images/warwickspons1small.png" alt="Warwick Sponsor">
-          <h4>Warwick, UK</h4>
+          <h4>Coventry, UK</h4>
       </div>
     </div>
     </div>
@@ -364,7 +364,7 @@
         </p>
       </div>
       <div class="postit europe col-sm-3 wowload fadeInLeft">
-        <h4>Warwick, UK</h4>
+        <h4>Coventry, UK</h4>
         <p>March 2-3</p>
         <p><i class="fa fa-map-marker"></i> University of Warwick</p>
         <p>Chair: Camille Maumet, Thomas Nichols, and Simon Schwab</p>

--- a/locations.html
+++ b/locations.html
@@ -329,7 +329,52 @@
      <hr>
    </div>
    <!-- end Cambridge -->
+       
+  <!-- start Warwick/Coventry -->
+  <div id="Warwick" class="container">
+    <div class="row">
+      <h2 class="text-center" id="warwick">Coventry, UK</h2>
 
+      <div class="col-md-8 col-md-offset-2">
+        <p><i class="fa fa-calendar"></i> March 2-3</p>
+        <p><i class="fa fa-map-marker"></i> <a href="https://www.google.com/maps/place/University+of+Warwick/@52.3792525,-1.5636591,17z/data=!4m5!3m4!1s0x48774ac696d53ee5:0xaa928d75708b2b54!8m2!3d52.3792525!4d-1.5614704"> University of Warwick</a>
+        </p>
+        <p><i class="fa fa-star"></i> Chair: Camille Maumet, Thomas Nichols, and Simon Schwab </p>
+
+
+        <p class="loacation-description">Registration is now open for <b>Brainhack Warwick 2017</b>. This 2-day workshop will be held <b>March 2nd - 3rd</b> at the University of Warwick, Coventry, UK, and is part of <a href="http://events.brainhack.org/global2017">Brainhack global</a>, where a constellation of such events happen simultaneously around the globe. Brainhack events convenes researchers from a myriad of disciplines to work together on projects related to neuroscience. Similar to hackathons in the tech sector, much of the schedule is left open for attendees to work together on projects of their choosing. We also include “unconference” sessions where talks are chosen by the attendees based on their interests as they evolve throughout the meeting. Brainhacks are not “coding sprints” or exclusive to programmers, but rather are open to brain scientists from all backgrounds.</p>
+        <p>Working papers on the outcomes from Brainhack Warwick can appear in the Gigascience Brainhack Thematic Series, and shorter project reports from the event are eligible for the annual Brainhack Proceedings.</p>
+        <p>Thanks to generous funding from the Wellcome Trust, registration is free, and includes 2 lunches, a conference dinner, all coffee breaks and parking. <b>To register, please email <a href="mailto:">brainhack2017-warwick@googlegroups.com</a> </b> with your name, affiliation, current position and area of expertise. Space is limited so please only register if you are able to attend, we will confirm your place by return email. Should delegates wish to book accommodation they can contact reservations on reservations@warwick.ac.uk or 02476 573925.</p>
+
+        <p>Already registered? <a href="http://events.brainhack.org/global2017/projects.html">Submit your project!</a>
+        </p>
+
+        <p>Contact: <a href="mailto:brainhack2017-warwick@googlegroups.com">brainhack2017-warwick@googlegroups.com</a>
+        <p>Website: <a href="https://brainhackwarwick.github.io/2017/">https://brainhackwarwick.github.io/2017/</a>
+        </p>
+
+
+        <h3>Schedule</h3>
+        <a href="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=WEEK&amp;dates=20170302%2F20170305&amp;height=500&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=ge9tmicimqubkeqggl3rt6fn3s%40group.calendar.google.com&amp;color=%232952A3&amp;ctz=Europe%2FLondon" target="_blank">Google Calendar</a>
+        <!-- <div class="text-center">
+          <div class="responsive-iframe-container">
+            <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=WEEK&amp;dates=20170302%2F20170305&amp;height=500&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=ge9tmicimqubkeqggl3rt6fn3s%40group.calendar.google.com&amp;color=%232952A3&amp;ctz=Europe%2FLondon" style="border-width:0" width="1000" height="500" frameborder="0" scrolling="no"></iframe>
+          </div>
+        </div> -->
+        <h3>Sponsors<h3>
+        <div class="row">
+          <div class="col-md-8 col-md-offset-2 text-center"><img src="images/warwickspons1.png" alt="partners"></div>
+        </div>
+
+        <h3>Organizers</h3>
+        <p class="col-md-3">Camille Maumet</p>
+        <p class="col-md-3">Thomas Nichols</p>
+        <p class="col-md-3">Simon Schwab</p>
+      </div>
+    </div>
+    <hr>
+  </div>
+  <!-- end Warwick/Coventry -->
    <!-- start
  g -->
    <div id="Leipzig" class="container">
@@ -506,52 +551,6 @@
      </div>
 
     <!-- end Stockholm -->
-
-    <!-- start Warwick -->
-  <div id="Warwick" class="container">
-    <div class="row">
-      <h2 class="text-center" id="warwick">Warwick, UK</h2>
-
-      <div class="col-md-8 col-md-offset-2">
-        <p><i class="fa fa-calendar"></i> March 2-3</p>
-        <p><i class="fa fa-map-marker"></i> <a href="https://www.google.com/maps/place/University+of+Warwick/@52.3792525,-1.5636591,17z/data=!4m5!3m4!1s0x48774ac696d53ee5:0xaa928d75708b2b54!8m2!3d52.3792525!4d-1.5614704"> University of Warwick</a>
-        </p>
-        <p><i class="fa fa-star"></i> Chair: Camille Maumet, Thomas Nichols, and Simon Schwab </p>
-
-
-        <p class="loacation-description">Registration is now open for <b>Brainhack Warwick 2017</b>. This 2-day workshop will be held <b>March 2nd - 3rd</b> at the University of Warwick, Coventry, UK, and is part of <a href="http://events.brainhack.org/global2017">Brainhack global</a>, where a constellation of such events happen simultaneously around the globe. Brainhack events convenes researchers from a myriad of disciplines to work together on projects related to neuroscience. Similar to hackathons in the tech sector, much of the schedule is left open for attendees to work together on projects of their choosing. We also include “unconference” sessions where talks are chosen by the attendees based on their interests as they evolve throughout the meeting. Brainhacks are not “coding sprints” or exclusive to programmers, but rather are open to brain scientists from all backgrounds.</p>
-        <p>Working papers on the outcomes from Brainhack Warwick can appear in the Gigascience Brainhack Thematic Series, and shorter project reports from the event are eligible for the annual Brainhack Proceedings.</p>
-        <p>Thanks to generous funding from the Wellcome Trust, registration is free, and includes 2 lunches, a conference dinner, all coffee breaks and parking. <b>To register, please email <a href="mailto:">brainhack2017-warwick@googlegroups.com</a> </b> with your name, affiliation, current position and area of expertise. Space is limited so please only register if you are able to attend, we will confirm your place by return email. Should delegates wish to book accommodation they can contact reservations on reservations@warwick.ac.uk or 02476 573925.</p>
-
-        <p>Already registered? <a href="http://events.brainhack.org/global2017/projects.html">Submit your project!</a>
-        </p>
-
-        <p>Contact: <a href="mailto:brainhack2017-warwick@googlegroups.com">brainhack2017-warwick@googlegroups.com</a>
-        <p>Website: <a href="https://brainhackwarwick.github.io/2017/">https://brainhackwarwick.github.io/2017/</a>
-        </p>
-
-
-        <h3>Schedule</h3>
-        <a href="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=WEEK&amp;dates=20170302%2F20170305&amp;height=500&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=ge9tmicimqubkeqggl3rt6fn3s%40group.calendar.google.com&amp;color=%232952A3&amp;ctz=Europe%2FLondon" target="_blank">Google Calendar</a>
-        <!-- <div class="text-center">
-          <div class="responsive-iframe-container">
-            <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=WEEK&amp;dates=20170302%2F20170305&amp;height=500&amp;wkst=2&amp;bgcolor=%23FFFFFF&amp;src=ge9tmicimqubkeqggl3rt6fn3s%40group.calendar.google.com&amp;color=%232952A3&amp;ctz=Europe%2FLondon" style="border-width:0" width="1000" height="500" frameborder="0" scrolling="no"></iframe>
-          </div>
-        </div> -->
-        <h3>Sponsors<h3>
-        <div class="row">
-          <div class="col-md-8 col-md-offset-2 text-center"><img src="images/warwickspons1.png" alt="partners"></div>
-        </div>
-
-        <h3>Organizers</h3>
-        <p class="col-md-3">Camille Maumet</p>
-        <p class="col-md-3">Thomas Nichols</p>
-        <p class="col-md-3">Simon Schwab</p>
-      </div>
-    </div>
-    <hr>
-  </div>
-  <!-- end Warwick -->
 
     <!-- start York -->
 <div id="York" class="container">


### PR DESCRIPTION
Hi,

This update changes "Warwick, UK" in "Coventry, UK" in the site listings and on the location page as the "University of Warwick" is located in the city of Coventry.

I did not update the `id` in the location page so that the site URL remains identical (i.e. http://events.brainhack.org/global2017/locations.html#warwick) as we have already advertised it.

Sorry for not catching this before. I hope this update will be okay. If not feel free to ignore those changes. Thank you!